### PR TITLE
remove link_names from SlackMessage

### DIFF
--- a/src/main/java/net/gpedro/integrations/slack/SlackMessage.java
+++ b/src/main/java/net/gpedro/integrations/slack/SlackMessage.java
@@ -17,7 +17,6 @@ public class SlackMessage {
 	private static final String UNFURL_LINKS = "unfurl_links";
 	private static final String TEXT = "text";
 	private static final String ATTACHMENTS = "attachments";
-	private static final String LINK_NAMES = "link_names";
 
 	private List<SlackAttachment> attach = new ArrayList<SlackAttachment>();
 	private String channel = null;
@@ -85,7 +84,6 @@ public class SlackMessage {
 
 		slackMessage.addProperty(UNFURL_MEDIA, unfurlMedia);
 		slackMessage.addProperty(UNFURL_LINKS, unfurlLinks);
-		slackMessage.addProperty(LINK_NAMES, linkNames);
 
 		if (text == null) {
 			throw new IllegalArgumentException("Missing Text field @ SlackMessage");


### PR DESCRIPTION
![Screen Shot 2019-04-12 at 12 29 03 PM](https://user-images.githubusercontent.com/5605580/56061539-944d3280-5d1e-11e9-8734-eaf251fe5f59.png)
